### PR TITLE
bugfix: When `file.type` is not `less`, call `done()` so that any remain...

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,7 +13,10 @@ var util = require("util");
  */
 module.exports = function (opts) {
     return function duoless(file, duo, done) {
-        if (file.type !== "less") return;
+        if (file.type !== "less") {
+          done();
+          return;
+        }
 
         debug("compiling %s to css", file.id);
 


### PR DESCRIPTION
...ing plugins finish executing
